### PR TITLE
Snarls

### DIFF
--- a/inc/stCactusGraphs.h
+++ b/inc/stCactusGraphs.h
@@ -276,6 +276,12 @@ uint64_t stSnarl_hashKey(const void *snarl);
 
 int stSnarl_equals(const void *snarl1, const void *snarl2);
 
+void stSnarl_print(stSnarl *snarl, FILE *fileHandle);
+
+void stSnarlDecomposition_destruct(stSnarlDecomposition *snarls);
+
+void stSnarlDecomposition_print(stSnarlDecomposition *snarls, FILE *fileHandle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/stCactusGraphs.h
+++ b/inc/stCactusGraphs.h
@@ -15,15 +15,6 @@ extern "C"{
 #endif
 
 /*
- * Plan:
- *
- * - Add better comments/docs
- * - Rename ultrabubbles snarls
- * - Add 1-terminal snarls to output
- * - Add ability to define path for top level chain from snarls
- */
-
-/*
  * The basic data structures representing a cactus graph
  */
 
@@ -98,14 +89,6 @@ typedef struct _stCactusGraphNodeIterator {
  * Snarls
  */
 
-// Ultra bubbles
-typedef struct _stUltraBubble stUltraBubble;
-struct _stUltraBubble {
-    stList *chains; // Each chain is an stList list of ultrabubbles in a sequence
-    // such that for i > 0, edgeEnd1 of ultrabubble i in the chain is the opposite end to edgeEnd2 of ultrabubble i-1.
-    stCactusEdgeEnd *edgeEnd1, *edgeEnd2;
-};
-
 typedef struct _stSnarl {
     // The boundaries of the snarl
     stCactusEdgeEnd *edgeEnd1, *edgeEnd2;
@@ -126,6 +109,9 @@ typedef struct _stSnarl {
 typedef struct _stSnarlDecomposition {
 	// List of top level chains. These chains may overlap.
 	stList *topLevelChains;
+
+	// Top level unary snarls
+	stList *topLevelUnarySnarls;
 
 } stSnarlDecomposition;
 
@@ -230,9 +216,6 @@ stList *stCactusGraph_getComponents(stCactusGraph *cactusGraph, bool ignoreBridg
 
 stHash *stCactusGraphComponents_getNodesToComponentsMap(stList *components);
 
-// Used to compute ultrabubbles, startNode may be NULL.
-stList *stCactusGraph_getUltraBubbles(stCactusGraph *graph, stCactusNode *startNode);
-
 int64_t stCactusGraph_getNodeNumber(stCactusGraph *graph);
 
 stSnarlDecomposition *stCactusGraph_getSnarlDecomposition(stCactusGraph *cactusGraph, stList *snarlChainEnds);
@@ -251,17 +234,6 @@ void stBridgeGraph_destruct(stBridgeGraph *bridgeGraph);
 void stBridgeNode_print(stBridgeNode *bridgeNode, FILE *fileHandle);
 
 stHash *stBridgeGraph_getBridgeEdgeEndsToBridgeNodesHash(stBridgeGraph *bridgeGraph);
-
-// Ultrabubbles
-
-stUltraBubble *stUltraBubble_construct(stList *parentChain,
-        stCactusEdgeEnd *edgeEnd1, stCactusEdgeEnd *edgeEnd2);
-
-void stUltraBubble_destruct(stUltraBubble *ultraBubble);
-
-void stUltraBubble_print(stUltraBubble *ultraBubble, FILE *fileHandle);
-
-void stUltraBubble_printChains(stList *ultraBubbleChains, FILE *fileHandle);
 
 // Snarls
 

--- a/inc/stCactusGraphs.h
+++ b/inc/stCactusGraphs.h
@@ -100,9 +100,8 @@ typedef struct _stSnarl {
     // The unary snarls contained in the snarl, for which edgeEnd1 == edgeEnd2
     stList *unarySnarls;
 
-    // Parent snarls, the snarls that this snarl is contained in -
-    // can be multiple, because top level traversals can overlap
-    stList *parentSnarls;
+    // The number of snarls / top-level chains this snarl is contained, vital for memory management
+    uint64_t parentCount;
 
 } stSnarl;
 
@@ -110,7 +109,7 @@ typedef struct _stSnarlDecomposition {
 	// List of top level chains. These chains may overlap.
 	stList *topLevelChains;
 
-	// Top level unary snarls
+	// Top level unary snarls, these are created by handing in a pair of equal bridge ends as telomeres
 	stList *topLevelUnarySnarls;
 
 } stSnarlDecomposition;
@@ -242,7 +241,7 @@ stSnarl *stSnarl_constructEmptySnarl(stCactusEdgeEnd *edgeEnd1, stCactusEdgeEnd 
 void stSnarl_destruct(stSnarl *snarl);
 
 stSnarl *stSnarl_makeRecursiveSnarl(stCactusEdgeEnd *edgeEnd1, stCactusEdgeEnd *edgeEnd2,
-		stSet *snarlCache, stSnarl *parentSnarl);
+		stSet *snarlCache);
 
 uint64_t stSnarl_hashKey(const void *snarl);
 

--- a/tests/allTests.c
+++ b/tests/allTests.c
@@ -20,6 +20,7 @@ int stPinchesAndCactiRunAllTests(void) {
     CuSuiteSummary(suite, output);
     CuSuiteDetails(suite, output);
     printf("%s\n", output->buffer);
+    CuStringDelete(output);
     return suite->failCount > 0;
 }
 

--- a/tests/stCactusGraphsTest.c
+++ b/tests/stCactusGraphsTest.c
@@ -72,7 +72,7 @@ static void setup() {
     stCactusGraph_collapseToCactus(g, mergeNodeObjects, n1);
 }
 
-static void invariantNodeTests(CuTest *testCase) {
+void invariantNodeTests(CuTest *testCase) {
     //Test the get object
     CuAssertPtrEquals(testCase, &nO1, stCactusNode_getObject(n1));
     CuAssertPtrEquals(testCase, &nO2, stCactusNode_getObject(n2));
@@ -115,7 +115,7 @@ static void invariantNodeTests(CuTest *testCase) {
     CuAssertPtrEquals(testCase, NULL, stCactusNodeEdgeEndIt_getNext(&it));
 }
 
-static void testStCactusNode(CuTest *testCase) {
+void testStCactusNode(CuTest *testCase) {
     setup();
     invariantNodeTests(testCase);
 
@@ -148,7 +148,7 @@ static void testStCactusNode(CuTest *testCase) {
     teardown();
 }
 
-static void testStCactusGraph(CuTest *testCase) {
+void testStCactusGraph(CuTest *testCase) {
     setup();
 
     //stCactusGraph_getNode
@@ -366,14 +366,14 @@ static void chainStructureTests(CuTest *testCase) {
     }
 }
 
-static void testStCactusEdgeEnd(CuTest *testCase) {
+void testStCactusEdgeEnd(CuTest *testCase) {
     setup();
     edgeEndTests(testCase);
     chainStructureTests(testCase);
     teardown();
 }
 
-static void testStCactusGraph_unmarkAndMarkCycles(CuTest *testCase) {
+void testStCactusGraph_unmarkAndMarkCycles(CuTest *testCase) {
     setup();
     stCactusGraph_unmarkCycles(g);
     edgeEndTests(testCase);
@@ -398,7 +398,7 @@ static void testStCactusGraph_unmarkAndMarkCycles(CuTest *testCase) {
     teardown();
 }
 
-static void testStCactusGraph_collapseBridges(CuTest *testCase) {
+void testStCactusGraph_collapseBridges(CuTest *testCase) {
     setup();
     stCactusGraph_collapseBridges(g, n1, mergeNodeObjects);
     n2 = stCactusGraph_getNode(g, &nO2);
@@ -480,7 +480,7 @@ bool endIsNotInChain(stCactusEdgeEnd *edgeEnd, void *endsNotInChainSet) {
     return stSet_search(endsNotInChainSet, edgeEnd) != NULL;
 }
 
-static void testStCactusGraph_breakChainsByEndsNotInChains(CuTest *testCase) {
+void testStCactusGraph_breakChainsByEndsNotInChains(CuTest *testCase) {
     setup();
     stCactusGraph_collapseBridges(g, n1, mergeNodeObjects);
     stSet *endsNotInChainSet = stSet_construct();
@@ -587,7 +587,7 @@ static void destroyRandomCactusGraph(struct RandomCactusGraph *rGraph) {
     free(rGraph);
 }
 
-static void testStCactusGraph_randomTest(CuTest *testCase) {
+void testStCactusGraph_randomTest(CuTest *testCase) {
     // Creates problem instances, then checks graph is okay by checking every edge
     // is properly connected, with right number of nodes and that everyone is in a chain
     for (int64_t test = 0; test < 1000; test++) {
@@ -755,7 +755,7 @@ static void makeComponent(stCactusNode *cactusNode, stSet *component, bool ignor
     }
 }
 
-static void testStCactusGraph_getComponents(CuTest *testCase) {
+void testStCactusGraph_getComponents(CuTest *testCase) {
     // Creates problem instances, then checks resulting component set.
     for (int64_t test = 0; test < 1000; test++) {
         // Make a random graph
@@ -916,7 +916,7 @@ static stSet *getNodesOnPathsBetweenBridgeEdgeEnds(stSet *cactusNodes) {
     return connectedCactusNodes;
 }
 
-static void testStCactusGraph_getBridgeGraphs(CuTest *testCase) {
+void testStCactusGraph_getBridgeGraphs(CuTest *testCase) {
     // Creates problem instances, then checks resulting component set.
     for (int64_t test = 0; test < 1000; test++) {
         // Make a random graph
@@ -1012,16 +1012,16 @@ static void testStCactusGraph_getBridgeGraphs(CuTest *testCase) {
     }
 }
 
-static void checkSnarlChain(CuTest *testCase, stList *chain, stSnarl *parent);
+static void checkSnarlChain(CuTest *testCase, stList *chain, bool hasParent);
 
-static void checkSnarl(CuTest *testCase, stSnarl *snarl, stSnarl *parent);
+static void checkSnarl(CuTest *testCase, stSnarl *snarl, bool hasParent);
 
-static void checkUnarySnarl(CuTest *testCase, stSnarl *snarl, stSnarl *parent);
+static void checkUnarySnarl(CuTest *testCase, stSnarl *snarl);
 
 static void checkNestedSnarls(CuTest *testCase, stSnarl *snarl) {
 	// Check nested unary snarls
 	for(int64_t i=0; i<stList_length(snarl->unarySnarls); i++) {
-		checkUnarySnarl(testCase, stList_get(snarl->unarySnarls, i), snarl);
+		checkUnarySnarl(testCase, stList_get(snarl->unarySnarls, i));
 	}
 
 	// Check nested chains
@@ -1030,20 +1030,17 @@ static void checkNestedSnarls(CuTest *testCase, stSnarl *snarl) {
 	}
 }
 
-static void checkUnarySnarl(CuTest *testCase, stSnarl *snarl, stSnarl *parent) {
+static void checkUnarySnarl(CuTest *testCase, stSnarl *snarl) {
 	// Check has just one boundary
 	CuAssertTrue(testCase, snarl->edgeEnd1 == snarl->edgeEnd2);
 
 	// Check is bridge
 	CuAssertTrue(testCase, stCactusEdgeEnd_getLink(snarl->edgeEnd1) == NULL);
 
-	// Check has reference to parent
-	CuAssertTrue(testCase, stList_contains(snarl->parentSnarls, parent));
-
 	checkNestedSnarls(testCase, snarl); // Recursively check children
 }
 
-static void checkSnarl(CuTest *testCase, stSnarl *snarl, stSnarl *parent) {
+static void checkSnarl(CuTest *testCase, stSnarl *snarl, bool hasParent) {
 	// Check not a unary snarl
 	CuAssertTrue(testCase, snarl->edgeEnd1 != snarl->edgeEnd2);
 
@@ -1054,7 +1051,7 @@ static void checkSnarl(CuTest *testCase, stSnarl *snarl, stSnarl *parent) {
         CuAssertTrue(testCase, stCactusEdgeEnd_getLink(snarl->edgeEnd2) == NULL);
 
         // Can not be nested
-        CuAssertTrue(testCase, parent == NULL);
+        CuAssertTrue(testCase, !hasParent);
     }
     else { // Is in a chain
         // Other end can not be a bridge
@@ -1064,17 +1061,12 @@ static void checkSnarl(CuTest *testCase, stSnarl *snarl, stSnarl *parent) {
         CuAssertTrue(testCase, stCactusEdgeEnd_getLink(snarl->edgeEnd1) == snarl->edgeEnd2);
         CuAssertTrue(testCase, stCactusEdgeEnd_getLink(snarl->edgeEnd2) == snarl->edgeEnd1);
         CuAssertTrue(testCase, stCactusEdgeEnd_getNode(snarl->edgeEnd1) == stCactusEdgeEnd_getNode(snarl->edgeEnd2));
-
-        // If parent is not null, check has reference to parent
-        if(parent != NULL) {
-        	CuAssertTrue(testCase, stList_contains(snarl->parentSnarls, parent));
-        }
     }
 
     checkNestedSnarls(testCase, snarl); // Recursively check children
 }
 
-static void checkSnarlChain(CuTest *testCase, stList *chain, stSnarl *parent) {
+static void checkSnarlChain(CuTest *testCase, stList *chain, bool hasParent) {
 	// Check chain is not empty
 	CuAssertTrue(testCase, stList_length(chain) > 0);
 
@@ -1089,25 +1081,41 @@ static void checkSnarlChain(CuTest *testCase, stList *chain, stSnarl *parent) {
 		}
 
 		// Recursively check the nested snarl
-		checkSnarl(testCase, snarl, parent);
+		checkSnarl(testCase, snarl, hasParent);
 	}
 }
 
 static void checkSnarlDecomposition(CuTest *testCase, stSnarlDecomposition *snarls, stList *telomeres) {
 
 	// Check we got the expected number of top level chains
-	CuAssertIntEquals(testCase, stList_length(snarls->topLevelChains), stList_length(telomeres)/2);
+	CuAssertIntEquals(testCase, stList_length(snarls->topLevelChains) + stList_length(snarls->topLevelUnarySnarls), stList_length(telomeres)/2);
 
-	// For each top level chain
-    for(int64_t i=0; i<stList_length(snarls->topLevelChains); i++) {
-        stList *chain = stList_get(snarls->topLevelChains, i);
+	// For each top level chain / unary snarl
+	int64_t i=0, j=0;
+    for(int64_t k=0; k<stList_length(telomeres); k+=2) {
+    	stCactusEdgeEnd *edgeEnd1 = stList_get(telomeres, k);
+    	stCactusEdgeEnd *edgeEnd2 = stList_get(telomeres, k+1);
 
-        // Check chain recursively
-        checkSnarlChain(testCase, chain, NULL);
+    	if(edgeEnd1 != edgeEnd2) { // Is a chain
+    		stList *chain = stList_get(snarls->topLevelChains, i++);
 
-        // Check boundaries are what we expect
-        CuAssertTrue(testCase, stList_get(telomeres, i*2) == ((stSnarl *)stList_get(chain, 0))->edgeEnd1);
-        CuAssertTrue(testCase, stList_get(telomeres, i*2+1) == ((stSnarl *)stList_peek(chain))->edgeEnd2);
+    		// Check chain, recursively
+    		checkSnarlChain(testCase, chain, 0);
+
+			// Check boundaries are what we expect
+			CuAssertTrue(testCase, edgeEnd1 == ((stSnarl *)stList_get(chain, 0))->edgeEnd1);
+			CuAssertTrue(testCase, edgeEnd2 == ((stSnarl *)stList_peek(chain))->edgeEnd2);
+    	}
+    	else { // is a unary snarl
+    		stSnarl *uSnarl = stList_get(snarls->topLevelUnarySnarls, j++);
+
+    		// Check unary snarl, recursively
+    		checkUnarySnarl(testCase, uSnarl);
+
+    		// Check boundaries are what we expect
+    		CuAssertTrue(testCase, edgeEnd1 == uSnarl->edgeEnd1);
+    		CuAssertTrue(testCase, edgeEnd1 == uSnarl->edgeEnd2);
+    	}
     }
 }
 
@@ -1210,20 +1218,20 @@ static void testStCactusGraph_randomSnarlTest(CuTest *testCase) {
         	addRandomTelomerePair(rGraph, telomeres);
         } while(st_random() > 0.5);
 
-
         // Make snarls
         stSnarlDecomposition *snarls = stCactusGraph_getSnarlDecomposition(rGraph->cactusGraph, telomeres);
 
         // Print the bridge graphs
-        stList *components = stCactusGraph_getComponents(rGraph->cactusGraph, 0);
+        /*stList *components = stCactusGraph_getComponents(rGraph->cactusGraph, 0);
         for(int64_t i=0; i<stList_length(components); i++) {
             stSet *component = stList_get(components, i);
             stBridgeGraph *bridgeGraph = stBridgeGraph_getBridgeGraph(stSet_peek(component));
             for(int64_t j=0; j<stList_length(bridgeGraph->bridgeNodes); j++) {
                 stBridgeNode_print(stList_get(bridgeGraph->bridgeNodes, j), stdout);
             }
+            stBridgeGraph_destruct(bridgeGraph);
         }
-        stList_destruct(components);
+        stList_destruct(components);*/
 
         // Print the snarl decomposition
         stSnarlDecomposition_print(snarls, stdout);

--- a/tests/stCactusGraphsTest.c
+++ b/tests/stCactusGraphsTest.c
@@ -1234,7 +1234,7 @@ static void testStCactusGraph_randomSnarlTest(CuTest *testCase) {
         stList_destruct(components);*/
 
         // Print the snarl decomposition
-        stSnarlDecomposition_print(snarls, stdout);
+        //stSnarlDecomposition_print(snarls, stdout);
 
         // Test the snarls
         checkSnarlDecomposition(testCase, snarls, telomeres);


### PR DESCRIPTION
Making a better, more comprehensive snarl decomposition that adds unary snarls and the ability to have multiple top-level chains (one for each chromosome), while still using memory only linearly proportional to the number of edges in the underlying graph.